### PR TITLE
Force cookie name to "sid"

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -10,10 +10,11 @@ pub fn with_session<T: SessionStore>(
     session_store: T,
     cookie_options: Option<CookieOptions>,
 ) -> impl Filter<Extract = (SessionWithStore<T>,), Error = Rejection> + Clone {
-    let cookie_options = match cookie_options {
+    let mut cookie_options = match cookie_options {
         Some(co) => co,
         None => CookieOptions::default(),
     };
+    cookie_options.cookie_name = "sid".to_owned();
     warp::any()
         .and(warp::any().map(move || session_store.clone()))
         .and(warp::cookie::optional("sid"))


### PR DESCRIPTION
Previously, we would always look for an incoming cookie named "sid" even
though CookieOptions could set an arbitary cookie name. In addition, the
default name when no CookieOptions was provided was "", so we'd set a
nameless cookie then try to get one named "sid".

Unfortunately, `warp::cookie::optional` takes a &'static str for the
cookie name, so there's not a good way to use the cookie name we get
from the CookieOptions struct. Until that changes, best fix is to just
force it to "sid" everywhere. Then at least warp-sessions works out of
the box.