### PR TITLE
Accept warp v0.4.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ repository = "https://github.com/ajpauwels/warp-sessions.git"
 async-session = "3.0.0"
 async-trait = "0.1.88"
 serde = { version = "1.0.219", features = ["derive"] }
-warp = "0.3.7"
+warp = ">=0.3.7, <0.5.0"
 tokio = { version = "1.47.1", features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
Hi, I just tried warp-sessions with warp v0.4.2.
Fortunately, it looks no modifications required around warp-sessions.

So, this PR relaxes warp requirements.
It may see some future incompatibilities, but I think strict version control can be taken on application side, if needed.

Thanks!